### PR TITLE
fix missing link for spreadsheet.css

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1,7 +1,7 @@
 /* You can add global styles to this file, and also import other style files */
 @import url('https://fonts.googleapis.com/css?family=Roboto');
 @import '~dhx-vault/codebase/vault.css';
-@import '~dhx-spreadsheet/codebase//spreadsheet.css';
+@import '~dhx-spreadsheet/codebase//spreadsheet.min.css';
 @import '~dhx-richtext/codebase//richtext.css';
 
 html, body {


### PR DESCRIPTION
I found build error what ``spreadsheet.css`` was not found in ``node_modules``.